### PR TITLE
rename git-main-branch variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased - [Github](https://github.com/boostsecurityio/boostsec-scanner-github/compare/v4.0.0..HEAD)
 
+## v4.0.1 - 2022-10-06 - [Github](https://github.com/boostsecurityio/boostsec-scanner-github/compare/v4.0.0...v4.0.1)
+
+- Bugfix main branch variable after cli rename
+
 ## v4.0.0 - 2022-10-05 - [Github](https://github.com/boostsecurityio/boostsec-scanner-github/compare/v3.0.0...v4.0.0)
 
 - The Boost CLI command and options has changed

--- a/lib/scan.sh
+++ b/lib/scan.sh
@@ -27,8 +27,8 @@ init.config ()
          BOOST_CLI_URL=${BOOST_CLI_URL%*/}
   export BOOST_DOWNLOAD_URL=${BOOST_DOWNLOAD_URL:-${BOOST_CLI_URL}/boost-cli/get-boost-cli}
 
-  export BOOST_MAIN_BRANCH
-         BOOST_MAIN_BRANCH=${BOOST_MAIN_BRANCH:-$(git.ls_remote)}
+  export BOOST_GIT_MAIN_BRANCH
+         BOOST_GIT_MAIN_BRANCH=${BOOST_GIT_MAIN_BRANCH:-$(git.ls_remote)}
 
   init.ci.config
 }

--- a/tests/lib.scan.bats
+++ b/tests/lib.scan.bats
@@ -6,7 +6,7 @@ setup ()
 
   PROJECT_ROOT=$(git rev-parse --show-toplevel)
 
-  export BOOST_MAIN_BRANCH="main" # do not attempt git ops
+  export BOOST_GIT_MAIN_BRANCH="main" # do not attempt git ops
 
   # shellcheck disable=SC1091
   source "${PROJECT_ROOT}/lib/scan.sh"
@@ -115,8 +115,8 @@ teardown ()
   assert_equal "${BOOST_LOG_COLORS}" true
 }
 
-@test "init.config BOOST_MAIN_BRANCH defined" {
-  export BOOST_MAIN_BRANCH=""
+@test "init.config BOOST_GIT_MAIN_BRANCH defined" {
+  export BOOST_GIT_MAIN_BRANCH=""
 
   pushd ${BATS_TEST_TMPDIR} > /dev/null
   git init test-repo
@@ -124,14 +124,14 @@ teardown ()
   git remote add origin https://github.com/bats-core/bats-core.git
   init.config
 
-  assert_equal "${BOOST_MAIN_BRANCH}" "master"
+  assert_equal "${BOOST_GIT_MAIN_BRANCH}" "master"
 }
 
-@test "init.config BOOST_MAIN_BRANCH preserved" {
-  export BOOST_MAIN_BRANCH="main"
+@test "init.config BOOST_GIT_MAIN_BRANCH preserved" {
+  export BOOST_GIT_MAIN_BRANCH="main"
   init.config
 
-  assert_equal "${BOOST_MAIN_BRANCH}" "main"
+  assert_equal "${BOOST_GIT_MAIN_BRANCH}" "main"
 }
 
 @test "init.cli creates tmpdir" {


### PR DESCRIPTION
resolves an issue detecting the git main branch