### PR TITLE
BST-12445: add main branch scan timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,15 @@ Optional path within the git repository to execute scanners in.
 
 When this parameter is specified, you must also provide a `scan_label` to identify the component.
 
-### `scan_timeout` (Optional, number)
+### `scan_timeout` (Optional, number) deprecated
 
 The optional timeout after which the Github check will be marked as failed. This defaults to 120 seconds.
+
+### `scan_diff_timeout` (Optional, number)
+
+The optional timeout on a diff scan after which the Github check will be marked as failed. This defaults to 120 seconds.
+
+### `scan_main_timeout` (Optional, number)
+
+The optional timeout on a main scan after which the Github check will be marked as failed. This defaults to 2 hours.
 

--- a/action.yaml
+++ b/action.yaml
@@ -43,7 +43,7 @@ inputs:
     description: "Optional relative path to scan"
     default: ""
   scan_timeout:
-    description: "Maximum amount of time a diff scan should complete in"
+    description: "Maximum amount of time a diff scan should complete in (deprecated)"
     default: ""
   scan_diff_timeout:
     description: "Maximum amount of time a diff scan should complete in"
@@ -65,7 +65,8 @@ runs:
         BOOST_GIT_MAIN_BRANCH: ${{ inputs.main_branch }}
         BOOST_IGNORE_FAILURE: ${{ inputs.ignore_failure }}
         BOOST_LOG_LEVEL: ${{ inputs.log_level }}
-        BOOST_DIFF_SCAN_TIMEOUT: ${{ (inputs.scan_diff_timeout == "") && inputs.scan_timeout || inputs.scan_diff_timeout }}
+        BOOST_SCAN_TIMEOUT: ${{ scan_timeout }}
+        BOOST_DIFF_SCAN_TIMEOUT: ${{ inputs.scan_diff_timeout }}
         BOOST_MAIN_SCAN_TIMEOUT: ${{ inputs.scan_main_timeout }}
         BOOST_PRE_SCAN: ${{ inputs.pre_scan_cmd }}
         BOOST_SCAN_LABEL: ${{ inputs.scan_label }}

--- a/action.yaml
+++ b/action.yaml
@@ -45,6 +45,12 @@ inputs:
   scan_timeout:
     description: "Maximum amount of time a diff scan should complete in"
     default: ""
+  scan_diff_timeout:
+    description: "Maximum amount of time a diff scan should complete in"
+    default: ""
+  scan_main_timeout:
+    description: "Maximum amount of time a main scan should complete in"
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -59,7 +65,8 @@ runs:
         BOOST_GIT_MAIN_BRANCH: ${{ inputs.main_branch }}
         BOOST_IGNORE_FAILURE: ${{ inputs.ignore_failure }}
         BOOST_LOG_LEVEL: ${{ inputs.log_level }}
-        BOOST_DIFF_SCAN_TIMEOUT: ${{ inputs.scan_timeout }}
+        BOOST_DIFF_SCAN_TIMEOUT: ${{ inputs.scan_diff_timeout == "" && inputs.scan_timeout || inputs.scan_diff_timeout }}
+        BOOST_MAIN_SCAN_TIMEOUT: ${{ inputs.scan_main_timeout }}
         BOOST_PRE_SCAN: ${{ inputs.pre_scan_cmd }}
         BOOST_SCAN_LABEL: ${{ inputs.scan_label }}
         BOOST_SCAN_PATH: ${{ inputs.scan_path }}

--- a/action.yaml
+++ b/action.yaml
@@ -65,7 +65,7 @@ runs:
         BOOST_GIT_MAIN_BRANCH: ${{ inputs.main_branch }}
         BOOST_IGNORE_FAILURE: ${{ inputs.ignore_failure }}
         BOOST_LOG_LEVEL: ${{ inputs.log_level }}
-        BOOST_DIFF_SCAN_TIMEOUT: ${{ inputs.scan_diff_timeout == "" && inputs.scan_timeout || inputs.scan_diff_timeout }}
+        BOOST_DIFF_SCAN_TIMEOUT: ${{ (inputs.scan_diff_timeout == "") && inputs.scan_timeout || inputs.scan_diff_timeout }}
         BOOST_MAIN_SCAN_TIMEOUT: ${{ inputs.scan_main_timeout }}
         BOOST_PRE_SCAN: ${{ inputs.pre_scan_cmd }}
         BOOST_SCAN_LABEL: ${{ inputs.scan_label }}

--- a/action.yaml
+++ b/action.yaml
@@ -65,7 +65,7 @@ runs:
         BOOST_GIT_MAIN_BRANCH: ${{ inputs.main_branch }}
         BOOST_IGNORE_FAILURE: ${{ inputs.ignore_failure }}
         BOOST_LOG_LEVEL: ${{ inputs.log_level }}
-        BOOST_SCAN_TIMEOUT: ${{ scan_timeout }}
+        BOOST_SCAN_TIMEOUT: ${{ inputs.scan_timeout }}
         BOOST_DIFF_SCAN_TIMEOUT: ${{ inputs.scan_diff_timeout }}
         BOOST_MAIN_SCAN_TIMEOUT: ${{ inputs.scan_main_timeout }}
         BOOST_PRE_SCAN: ${{ inputs.pre_scan_cmd }}

--- a/lib/scan.sh
+++ b/lib/scan.sh
@@ -20,6 +20,8 @@ init.config ()
 {
   log.info "initializing configuration"
 
+  export BOOST_DIFF_SCAN_TIMEOUT=${BOOST_DIFF_SCAN_TIMEOUT:-${BOOST_SCAN_TIMEOUT:-}}
+
   export BOOST_TMP_DIR=${BOOST_TMP_DIR:-${WORKSPACE_TMP:-${TMPDIR:-/tmp}}}
   export BOOST_EXE=${BOOST_EXE:-${BOOST_TMP_DIR}/boost-cli/latest}
 


### PR DESCRIPTION
add `scanDiffTimeout` to phase out `scanTimeout` for non-main branch timeouts
add `scanMainTimeout` for main branch timeouts